### PR TITLE
Adding localhost and ars.transltr.io to the ALLOWED_HOSTS

### DIFF
--- a/tr_sys/tr_sys/settings.py
+++ b/tr_sys/tr_sys/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'a=()q#x6$s_2tnzgvoudd=5&gbv*57bcr(^%f)&rp-7ydf(9ao'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['ars.transltr.io','localhost']
 
 
 # Application definition


### PR DESCRIPTION
I believe the reason for the previous discrepancy in performance between local testing and production stemmed from the queries and responses being erroneously disallowed in production because 'localhost' was not among the allowed hosts in Django.  This resulted in a code other than 200 being returned and the results not showing for the new registrations.  I have tested this in production and believe this addition to settings.py should resolve the issue.