### PR TITLE
Register explanatory agent

### DIFF
--- a/server.py
+++ b/server.py
@@ -47,8 +47,10 @@ def execUnsecret(unsecret):
                 response = requests.get(server+"/ars/api/messages/"+child["message"])
                 print(str(response.json())[:500])
                 answer = response.json()
-                assert len(answer["fields"]["data"]["results"]) > 1
-                return
+                if answer["fields"]["status"] != "Running":
+                    print("retrieved message: "+response.url)
+                    assert len(answer["fields"]["data"]["results"]) > 1
+                    return
     sys.stderr.write("Could not find Unsecret message response!\n")
     assert unsecret < 0
     return message

--- a/tr_sys/tr_ara_explanatory/explanatoryStatusQuery.json
+++ b/tr_sys/tr_ara_explanatory/explanatoryStatusQuery.json
@@ -1,0 +1,25 @@
+{
+    "message": {
+        "query_graph": {
+            "edges": [
+                {
+                    "id": "e00",
+                    "source_id": "n00",
+                    "target_id": "n01",
+                    "type": "associated"
+                }
+            ],
+            "nodes": [
+                {
+                    "curie": "EFO:0005208",
+                    "id": "n00",
+                    "type": "disease"
+                },
+                {
+                    "id": "n01",
+                    "type": "gene"
+                }
+            ]
+        }
+    }
+}

--- a/tr_sys/tr_ara_explanatory/explanatory_app.py
+++ b/tr_sys/tr_ara_explanatory/explanatory_app.py
@@ -1,0 +1,24 @@
+from tr_ars.default_ars_app.ars_app import AppConfig as ARSAppConfig
+from django.urls import path, include
+from tr_ars.default_ars_app.api import *
+
+class AppConfig(ARSAppConfig):
+    name = 'tr_ara_explanatory.explanatory_app' # must be dot path for module
+    actors = [('http://explanatory-agent.azurewebsites.net/agent', 'runquery', 'general')] # tuple of remote, name, channel
+    app_path = 'ara-explanatory'
+    regex_path = '^' + app_path + '/'
+
+### code below this line is required, but doesn't require updating in most cases
+
+apipatterns = [path(r'', init_api_index(AppConfig.actors, AppConfig.app_path), name=AppConfig.app_path + '-api')]
+for actor in AppConfig.actors:
+    query_path = actor[1]
+    query_name = AppConfig.app_path + '-' + query_path
+    apipatterns.append(path(query_path, init_api_fn(actor), name=query_name))
+
+urlpatterns = [
+    path(r'', init_redirect(AppConfig.app_path), name=AppConfig.app_path + '-base'),
+    path(r'api/', include(apipatterns)),
+]
+
+

--- a/tr_sys/tr_ars/default_ars_app/api.py
+++ b/tr_sys/tr_ars/default_ars_app/api.py
@@ -17,7 +17,8 @@ def index(req):
                             reverse('run-app-query')))
 
 def query(url, data, timeout=600):
-    r = requests.post(url, json=data, timeout=timeout)
+    headers = {'Content-Type': 'application/json'}
+    r = requests.post(url, json=data, headers=headers, timeout=timeout)
     logger.debug('%d: %s\n%s' % (r.status_code, r.headers, r.text[:500]))
     return r
 

--- a/tr_sys/tr_ars/tasks.py
+++ b/tr_sys/tr_ars/tasks.py
@@ -23,11 +23,16 @@ def send_message(actor_dict, mesg_dict, timeout=60):
         'uri': url
     }
     mesg = Message.create(actor=Actor.objects.get(pk=actor_dict['pk']),
-                          name=mesg_dict['fields']['name'], status='U',
+                          name=mesg_dict['fields']['name'], status='R',
                           ref=Message.objects.get(pk=mesg_dict['pk']))
     mesg.save()
-    callback = settings.DEFAULT_HOST + reverse('ars-messages') + '/' + str(mesg.pk)
-    data['fields']['data']['callback'] = callback
+
+    # TODO Add Translator API Version to Actor Model ... here one expects strict 0.92 format
+    if actor_dict['fields']['name'].find('ara-explanatory') == 0:
+        pass
+    else:
+        callback = settings.DEFAULT_HOST + reverse('ars-messages') + '/' + str(mesg.pk)
+        data['fields']['data']['callback'] = callback
 
     try:
         r = requests.post(url, json=data, timeout=timeout)

--- a/tr_sys/tr_ars/tasks.py
+++ b/tr_sys/tr_ars/tasks.py
@@ -28,7 +28,7 @@ def send_message(actor_dict, mesg_dict, timeout=60):
     mesg.save()
 
     # TODO Add Translator API Version to Actor Model ... here one expects strict 0.92 format
-    if actor_dict['fields']['name'].find('ara-explanatory') == 0:
+    if 'url' in actor_dict['fields'] and actor_dict['fields']['url'].find('/ara-explanatory/api/runquery') == 0:
         pass
     else:
         callback = settings.DEFAULT_HOST + reverse('ars-messages') + '/' + str(mesg.pk)

--- a/tr_sys/tr_sys/settings.py
+++ b/tr_sys/tr_sys/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'tr_ara_aragorn.aragorn_app.AppConfig',
     'tr_ara_arax.arax_app.AppConfig',
     'tr_ara_bte.bte_app.AppConfig',
+    'tr_ara_explanatory.explanatory_app.AppConfig',
     'tr_ara_ncats.ncats_app.AppConfig',
     'tr_ara_robokop.robokop_app.AppConfig',
     'tr_ara_unsecret.unsecret_app.AppConfig',

--- a/tr_sys/tr_sys/urls.py
+++ b/tr_sys/tr_sys/urls.py
@@ -23,6 +23,7 @@ from django.urls import include, path, reverse
 from tr_ara_aragorn.aragorn_app import AppConfig as AragornApp
 from tr_ara_arax.arax_app import AppConfig as ARAXApp
 from tr_ara_bte.bte_app import AppConfig as BTEApp
+from tr_ara_explanatory.explanatory_app import AppConfig as ExplanatoryApp
 from tr_ara_ncats.ncats_app import AppConfig as NCATSApp
 from tr_ara_robokop.robokop_app import AppConfig as RobokopApp
 from tr_ara_unsecret.unsecret_app import AppConfig as UnsecretApp
@@ -38,6 +39,7 @@ patterns = [
     url(ARAXApp.regex_path,include(ARAXApp.name)),
     url(BTEApp.regex_path, include(BTEApp.name)),
     url(NCATSApp.regex_path,include(NCATSApp.name)),
+    url(ExplanatoryApp.regex_path,include(ExplanatoryApp.name)),
     url(RobokopApp.regex_path, include(RobokopApp.name)),
     url(UnsecretApp.regex_path, include(UnsecretApp.name)),
     url(GeneticsApp.regex_path,include(GeneticsApp.name)),


### PR DESCRIPTION
Replaces previous pull request for new explanatory agent registration https://github.com/NCATSTranslator/Relay/pull/47 with a minor temp fix; actors need to set Translator API version of compliance