### PR TITLE
feat: :sparkles: register bte TRAPI 1.0.0

### DIFF
--- a/data/fixtures/actors.json
+++ b/data/fixtures/actors.json
@@ -25,7 +25,7 @@
         "fields": {
             "channel": 1,
             "agent": 3,
-            "remote": "https://api.bte.ncats.io/query",
+            "remote": "https://api.bte.ncats.io/v1/query",
             "path": "runquery"
         }
     },

--- a/tr_sys/tr_ara_bte/actor_bte.json
+++ b/tr_sys/tr_ara_bte/actor_bte.json
@@ -5,5 +5,5 @@
         "uri": "http://localhost:8000/ara-bte/api/"
     },
     "path": "runquery",
-    "remote": "https://api.bte.ncats.io/query"
+    "remote": "https://api.bte.ncats.io/v1/query"
 }

--- a/tr_sys/tr_ara_bte/bte_app.py
+++ b/tr_sys/tr_ara_bte/bte_app.py
@@ -4,7 +4,7 @@ from tr_ars.default_ars_app.api import *
 
 class AppConfig(ARSAppConfig):
     name = 'tr_ara_bte.bte_app' # must be dot path for module
-    actors = [('https://api.bte.ncats.io/query', 'runquery', 'general')] # tuple of remote, name, channel
+    actors = [('https://api.bte.ncats.io/v1/query', 'runquery', 'general')] # tuple of remote, name, channel
     app_path = 'ara-bte'
     regex_path = '^' + app_path + '/'
 


### PR DESCRIPTION
Update registered url of BTE to point to TRAPI 1.0.0 implementation of BTE.