### PR TITLE
Status report now skips actors marked inactive

### DIFF
--- a/tr_sys/tr_ars/status_report.py
+++ b/tr_sys/tr_ars/status_report.py
@@ -73,6 +73,8 @@ def status_ars(req, smartresponse, smartapis):
     response['actors'] = dict()
     for a in Actor.objects.exclude(path__exact=''):
         actor = json.loads(serializers.serialize('json', [a]))[0]
+        if(not a.active):
+            continue
         del actor['fields']
         #actor['name'] = a.agent.name + '-' + a.path
         actor['channel'] = a.channel.name


### PR DESCRIPTION
Pretty simple fix, but this should have the status page entirely skip actors that are marked as not active through the django admin console