### PR TITLE
update imProving Agent URL for TRAPI 1.2

### DIFF
--- a/tr_sys/tr_ara_improving/improving_app.py
+++ b/tr_sys/tr_ara_improving/improving_app.py
@@ -4,7 +4,7 @@ from tr_ars.default_ars_app.api import *
 
 class AppConfig(ARSAppConfig):
     name = 'tr_ara_improving.improving_app' # must be dot path for module
-    actors = [('https://ia.healthdatascience.cloud/api/v1.1/query', 'runquery', 'general')] # tuple of remote, name, channel
+    actors = [('https://ia.healthdatascience.cloud/api/v1.2/query', 'runquery', 'general')] # tuple of remote, name, channel
     app_path = 'ara-improving'
     regex_path = '^' + app_path + '/'
 


### PR DESCRIPTION
Updates the imProving Agent registration with a new URL for TRAPI 1.2