### PR TITLE
adding sqlite capable check for is_active

### DIFF
--- a/tr_sys/tr_ars/pubsub.py
+++ b/tr_sys/tr_ars/pubsub.py
@@ -15,7 +15,8 @@ def send_messages(actors, messages):
             if (actor == mesg.actor or len(actor.path) == 0
                 or len(actor.agent.uri) == 0):
                 pass
-            elif actor.active=="0":
+            #mysql vs sqlite handle this field differently; checking for both ways
+            elif not actor.active or actor.active=="0":
                 logger.debug("Skipping actor %s/%s; it's inactive..." % (
                     actor.agent, actor.url()))
             elif settings.USE_CELERY:


### PR DESCRIPTION
The system seems to vary in whether it uses 1/0 or True/False.  I'm looking into why that's the case (doesn't seem like it should be) but this should be a harmless fix to work with either setup, which is probably preferable since some people spinning up their own instance may be using sqlite or mysql.  We should support both.