### PR TITLE
Knocking our SmartAPI back to http vs https

### DIFF
--- a/tr_sys/tr_smartapi_client/smart_api_discover.py
+++ b/tr_sys/tr_smartapi_client/smart_api_discover.py
@@ -61,7 +61,7 @@ class ConfigFile:
     to cache the last known successfully fetched configuration.
 """
 
-urlSmartapi = "https://smart-api.info"
+urlSmartapi = "http://smart-api.info"
 secsTimeout = 5
 
 class UrlMapSmartApiFetcher(object):


### PR DESCRIPTION
Temporary fix, but will resolve the issues we were seeing negotiating tlsv1.3 which is the only protocol that SmartAPI accepts and Python seems to not support it well
