### PR TITLE
Async timeout query limits

### DIFF
--- a/tr_sys/tr_ars/tasks.py
+++ b/tr_sys/tr_ars/tasks.py
@@ -140,7 +140,8 @@ def send_message(actor_dict, mesg_dict, timeout=300):
 def catch_timeout_async():
     now =timezone.now()
     time_threshold = now - timezone.timedelta(minutes=60)
-    messages = Message.objects.filter(timestamp__lt=time_threshold, status__in='R')
+    max_time = now - timezone.timedelta(days=1)
+    messages = Message.objects.filter(timestamp__lt=time_threshold, timestamp__gt=max_time,status__in='R')
     for mesg in messages:
         agent = str(mesg.actor.agent.name)
         if agent == 'ars-default-agent':

--- a/tr_sys/tr_ars/tasks.py
+++ b/tr_sys/tr_ars/tasks.py
@@ -141,7 +141,7 @@ def catch_timeout_async():
     now =timezone.now()
     time_threshold = now - timezone.timedelta(minutes=60)
     max_time = now - timezone.timedelta(days=1)
-    messages = Message.objects.filter(timestamp__lt=time_threshold, timestamp__gt=max_time,status__in='R')
+    messages = Message.objects.filter(timestamp__gt=max_time,timestamp__lt=time_threshold,status__in='R')
     for mesg in messages:
         agent = str(mesg.actor.agent.name)
         if agent == 'ars-default-agent':


### PR DESCRIPTION
Adding limits to the query used to check for async timeouts. This should hopefully run in a more efficient manner in environments with larger databases.