### PR TITLE
moved save of sync responses to after pre-processing

### DIFF
--- a/tr_sys/tr_ars/tasks.py
+++ b/tr_sys/tr_ars/tasks.py
@@ -117,14 +117,14 @@ def send_message(actor_dict, mesg_dict, timeout=300):
                         #message_to_merge = utils.get_safe(rdata,"message")
                         message_to_merge=rdata
                         agent_name = str(mesg.actor.agent.name)
+
+                        utils.pre_merge_process(message_to_merge,mesg_dict['pk'], agent_name)
                         mesg.code = status_code
                         mesg.status = status
                         mesg.data = rdata
                         mesg.url = url
                         mesg.save()
                         logger.debug('+++ message saved: %s' % (mesg.pk))
-                        utils.pre_merge_process(message_to_merge,mesg_dict['pk'], agent_name)
-
                         if agent_name.startswith('ara-'):
                             new_merged = utils.merge_received(parent_pk,message_to_merge['message'], agent_name)
                             utils.post_process(new_merged.data,new_merged.pk, agent_name)


### PR DESCRIPTION
This will address the issue wherein Unsecret (and I imagine any other sync tools) were not showing properly normalized nodes.