### PR TITLE
Changing exception handling for original returns to only apply to those

### DIFF
--- a/tr_sys/tr_ars/tasks.py
+++ b/tr_sys/tr_ars/tasks.py
@@ -112,31 +112,18 @@ def send_message(actor_dict, mesg_dict, timeout=300):
                     mesg.result_count = len(rdata["message"]["results"])
                     scorestat = utils.ScoreStatCalc(results)
                     mesg.result_stat = scorestat
-                    try:
-                        parent_pk = mesg.ref.id
-                        #message_to_merge = utils.get_safe(rdata,"message")
-                        message_to_merge=rdata
-                        agent_name = str(mesg.actor.agent.name)
+                    parent_pk = mesg.ref.id
+                    #message_to_merge = utils.get_safe(rdata,"message")
+                    message_to_merge=rdata
+                    agent_name = str(mesg.actor.agent.name)
 
-                        utils.pre_merge_process(message_to_merge,mesg_dict['pk'], agent_name, inforesid)
-                        mesg.code = status_code
-                        mesg.status = status
-                        mesg.data = rdata
-                        mesg.url = url
-                        mesg.save()
-                        logger.debug('+++ message saved: %s' % (mesg.pk))
-                        if agent_name.startswith('ara-'):
-                            new_merged = utils.merge_received(parent_pk,message_to_merge['message'], agent_name)
-                            utils.post_process(new_merged.data,new_merged.pk, agent_name)
-
-                    except Exception as e:
-                        logger.debug('Problem with post processing or merger of %s for pk: %s' % (inforesid, mesg.pk))
-                        new_merged.status='E'
-                        new_merged.code = 422
-                        new_merged.save()
-
-            if 'tr_ars.message.status' in r.headers:
-                status = r.headers['tr_ars.message.status']
+                    utils.pre_merge_process(message_to_merge,mesg_dict['pk'], agent_name, inforesid)
+                    mesg.code = status_code
+                    mesg.status = status
+                    mesg.data = rdata
+                    mesg.url = url
+                    mesg.save()
+                    logger.debug('+++ message saved: %s' % (mesg.pk))
         else:
             if r.status_code == 202:
                 status = 'W'
@@ -167,6 +154,19 @@ def send_message(actor_dict, mesg_dict, timeout=300):
         mesg.url = url
         mesg.save()
         logger.debug('+++ message saved: %s' % (mesg.pk))
+    try:
+        if agent_name.startswith('ara-'):
+            new_merged = utils.merge_received(parent_pk,message_to_merge['message'], agent_name)
+            utils.post_process(new_merged.data,new_merged.pk, agent_name)
+
+    except Exception as e:
+        logger.debug('Problem with post processing or merger of %s for pk: %s' % (inforesid, mesg.pk))
+        new_merged.status='E'
+        new_merged.code = 422
+        new_merged.save()
+
+
+
 
 
 


### PR DESCRIPTION
This should stop Unsecret's original response from being marked as 500 despite being normal and having results, but does not address the root of the problem, which is an intermittent issue with a NoneType coming through instead of a Message for the merged_version.  I would say that this likely does not qualify as a showstopper fix and should remain in CI/Dev until code thaw.