### PR TITLE
Exempting merged_versions from timeout

### DIFF
--- a/tr_sys/tr_ars/tasks.py
+++ b/tr_sys/tr_ars/tasks.py
@@ -191,8 +191,8 @@ def catch_timeout_async():
         id = mesg[1]
         actor = Agent.objects.get(pk=mpk)
         logging.info(f'actor: {actor} id: {mesg[1]} timestamp: {mesg[2]} updated_at {mesg[3]}')
-
-        if actor.name == 'ars-default-agent':
+        #exempting parents and merged_versions from timing out
+        if actor.name == 'ars-default-agent' or actor.name =='ars-ars-agent':
             continue
         else:
             logging.info(f'for actor: {actor.name}, and pk {str(id)} the status is still "Running" after 5 min, setting code to 598')


### PR DESCRIPTION
I'm still seeing some merged versions timing out (and seemingly at less than 5 minutes) in CI.  This should just exempt merged versions from being timed out.  Not ideal, but may be what we need to get testing working.
https://ars.ci.transltr.io/ars/api/messages/5858308c-e399-4d71-ac2b-679967ff6c03?trace=y