### PR TITLE
Switch production deployment to gunicorn

### DIFF
--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -20,7 +20,21 @@ spec:
           image: "{{ .Values.arsserver.image.repository }}:{{ .Values.arsserver.image.tag }}"
           imagePullPolicy: {{ .Values.arsserver.image.PullPolicy }}
           command: ["/bin/sh"]
-          args: ["-c", "/bin/bash /ars/config/startup.sh && python tr_sys/manage.py runserver 0.0.0.0:8000 --noreload"]
+          args:
+            - "-c"
+            - >-
+              /bin/bash /ars/config/startup.sh &&
+              gunicorn tr_sys.wsgi:application
+              --chdir /ars/tr_sys
+              --bind 0.0.0.0:{{ .Values.arsserver.containerPort }}
+              --worker-class {{ .Values.arsserver.gunicorn.workerClass | default "gthread" }}
+              --workers {{ .Values.arsserver.gunicorn.workers | default 4 }}
+              --threads {{ .Values.arsserver.gunicorn.threads | default 4 }}
+              --timeout {{ .Values.arsserver.gunicorn.timeout | default 360 }}
+              --graceful-timeout {{ .Values.arsserver.gunicorn.gracefulTimeout | default 120 }}
+              --max-requests {{ .Values.arsserver.gunicorn.maxRequests | default 1000 }}
+              --max-requests-jitter {{ .Values.arsserver.gunicorn.maxRequestsJitter | default 100 }}
+              --access-logfile - --error-logfile -
           ports:
             - containerPort: {{ .Values.arsserver.containerPort }}
           volumeMounts:

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -12,7 +12,6 @@ arsserver:
     PullPolicy: Always
   containerPort: 8000
   gunicorn:
-    # gevent is intentionally NOT used: mysqlclient is a blocking C extension and does not cooperate with greenlets.
     workerClass: gthread
     # Tune workers/threads to the pod's CPU/memory allocation.
     # The general recommendation is workers = 2 * cpu cores + 1

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -10,7 +10,19 @@ arsserver:
     repository: 853771734544.dkr.ecr.us-east-1.amazonaws.com/translator-ars
     tag: DOCKER_VERSION_VALUE
     PullPolicy: Always
-  containerPort: 8000  
+  containerPort: 8000
+  gunicorn:
+    # gevent is intentionally NOT used: mysqlclient is a blocking C extension and does not cooperate with greenlets.
+    workerClass: gthread
+    # Tune workers/threads to the pod's CPU/memory allocation.
+    # The general recommendation is workers = 2 * cpu cores + 1
+    # With a gthread worker, concurrency ~= workers * threads.
+    workers: 4
+    threads: 4
+    timeout: 360          # hard kill a request so a worker isn't hogged when it's stuck on one query
+    gracefulTimeout: 120  # padding time for workers to complete running queries before restarting
+    maxRequests: 1000     # recycle workers periodically to prevent issues with memory/connection leaks etc
+    maxRequestsJitter: 100  # randomize when workers restart to avoid happening all at once
   env:
     TR_ENV: TR_ENV_VALUE
     TR_APPRAISE: TR_APPRAISE_VALUE
@@ -28,7 +40,7 @@ rabbitmq:
     repository: 853771734544.dkr.ecr.us-east-1.amazonaws.com/translator-rabbitmq
     tag: 4.0
     PullPolicy: Always
-  containerPort: 5672  
+  containerPort: 5672
 
 redis:
   image:
@@ -46,7 +58,7 @@ affinity:
         - key: application
           operator: In
           values:
-          - ars   
+          - ars
 tolerations:
   - key: "transltr"
     value: "ars"
@@ -66,8 +78,8 @@ ingress:
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
-    alb.ingress.kubernetes.io/success-codes: '200'  
+    alb.ingress.kubernetes.io/success-codes: '200'
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=600
-  host: ARS_HOSTNAME_VALUE    
+  host: ARS_HOSTNAME_VALUE
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -139,6 +139,7 @@ sphinx==4.5.0
 elasticsearch~=7.9.1
 tblib~=1.7.0
 gevent~=21.8.0
+gunicorn~=22.0.0
 mysqlclient~=1.4.3
 colorama~=0.4.4
 jinja2~=3.1.2


### PR DESCRIPTION
Unless there is another helm chart living somewhere else, we're running Django's development server (manage.py runserver) in production. That is not recommended by Django and can cause serious performance issues:
- It's just one python process with one GIL. CPU intensive tasks block every other process.
- It doesn't have great restart and recycling capabilities, if it gets to a completely hung state there's no recourse and the best case scenario is k8s kills it and spins up an entirely new instance with hard down time in between

Switching to gunicorn with workers solves a lot of those issues:
- Workers have their own python processes with their own GIL which enables real concurrency that can scale by adding more cpu & workers (cpu hogging tasks only block their own worker) 
- Workers can crash and restart and are automatically recycled periodically intentionally, while other workers are still processing requests
- Better logging and understanding of these restarts

If we adopt this, we'll want to add the new gunicorn values to our ncats-values files, and it's strongly recommended to tune the number of workers according to the amount of CPU we have allocated. Comments in the chart show where/how to do that.

Along with this, it is highly recommended that we double check the settings not committed to this repo (deploy/configs/settings.py) and make sure Django is not being run in DEBUG mode for CI, test, or prod, and probably we don't need DJANGO_LOG_LEVEL=DEBUG there either. It might be nice to use environment variables configurable from helm values for these to make it easy to set them per-maturity-level.