### PR TITLE
Fix hard coded token limit

### DIFF
--- a/tr_sys/tr_ars/utils.py
+++ b/tr_sys/tr_ars/utils.py
@@ -706,7 +706,7 @@ def merge_and_post_process(self, parent_pk,message_to_merge, agent_name):
     logging.info(f"🚀Starting merge for %s with parent PK: %s"% (agent_name,parent_pk))
     try:
         #Acquire an expensive token so we don't hold DB locked while waiting
-        with expensive_section(self, limit=6):
+        with expensive_section(self):
             logging.info("[%s] 🟢 acquired expensive token", self.request.id)
 
             # short critical section: lock row + decide if we can merge

--- a/tr_sys/tr_sys/celery_gates/context.py
+++ b/tr_sys/tr_sys/celery_gates/context.py
@@ -3,15 +3,15 @@
 # Relay/tr_sys/tr_sys/celery_gates/context.py
 from contextlib import contextmanager
 from celery.exceptions import Retry, MaxRetriesExceededError
-from .expensive_gate import try_acquire, release, LeaseRenewer, exp_backoff_with_jitter, DEFAULT_LIMIT
+from .expensive_gate import try_acquire, release, LeaseRenewer, exp_backoff_with_jitter, ARS_EXPENSIVE_TOKEN_LIMIT
 from celery.utils.log import get_task_logger
 logger = get_task_logger(__name__)
 
 @contextmanager
-def expensive_section(task_self, limit: int = DEFAULT_LIMIT):
+def expensive_section(task_self, limit: int = ARS_EXPENSIVE_TOKEN_LIMIT):
     """
     Usage: inside a Celery task with `bind=True`:
-        with expensive_section(self, limit=6):
+        with expensive_section(self):
             # do expensive work
     If acquire fails -> raises self.retry(...) to requeue quickly.
     """

--- a/tr_sys/tr_sys/celery_gates/expensive_gate.py
+++ b/tr_sys/tr_sys/celery_gates/expensive_gate.py
@@ -13,7 +13,7 @@ logger = get_task_logger(__name__)
 # Config via env (set these in your Helm values / CI)
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
 ZKEY = os.getenv("ARS_EXPENSIVE_ZKEY", "ars:expensive_tokens")
-DEFAULT_LIMIT = int(os.getenv("ARS_EXPENSIVE_LIMIT", "12"))       # default token limit
+ARS_EXPENSIVE_TOKEN_LIMIT = int(os.getenv("ARS_EXPENSIVE_LIMIT", "12"))       # default token limit
 LEASE_MS = int(os.getenv("ARS_EXPENSIVE_LEASE_MS", "180000"))   # default lease 3 minutes (ms)
 RENEW_EVERY_SEC = int(os.getenv("ARS_EXPENSIVE_RENEW_SEC", "15"))  # renew interval
 
@@ -56,13 +56,11 @@ def now_ms() -> int:
     return int(time.time() * 1000)
 
 
-def try_acquire(task_id: str, limit: Optional[int] = None) -> bool:
+def try_acquire(task_id: str, limit: int = ARS_EXPENSIVE_TOKEN_LIMIT) -> bool:
     """
     Atomically attempt to acquire a lease token for task_id.
     Returns True when token claimed, False otherwise.
     """
-    if limit is None:
-        limit = DEFAULT_LIMIT
     script = _load_acquire_script()
     try:
         res = script(keys=[ZKEY], args=[now_ms(), LEASE_MS, limit, task_id])


### PR DESCRIPTION
We are working on tuning task concurrency and retry functionality. The default value for the ARS_EXPENSIVE_LIMIT env var, which controls the number of available tokens for concurrent tasks, was recently increased from 6 to 12, which is good, but in tr_sys/tr_ara/utils.py a call to expensive_section() still hard coded this limit to 6, ignoring the value set by the env var.

This PR removes that hardcoded value and renames the previous python constant used for this setting "DEFAULT_LIMIT" to a more explicit "ARS_EXPENSIVE_TOKEN_LIMIT". This still doesn't match the env var, which might be nice, but keeping the env var the same avoids breaking configs external to this repo (ie jenkins).