### PR TITLE
Merge Task Retry Handling & Performance

### DIFF
--- a/tr_sys/tr_ars/utils.py
+++ b/tr_sys/tr_ars/utils.py
@@ -706,7 +706,7 @@ def merge_and_post_process(self, parent_pk,message_to_merge, agent_name):
     logging.info(f"🚀Starting merge for %s with parent PK: %s"% (agent_name,parent_pk))
     try:
         #Acquire an expensive token so we don't hold DB locked while waiting
-        with expensive_section(self, limit=6):
+        with expensive_section(self):
             logging.info("[%s] 🟢 acquired expensive token", self.request.id)
 
             # short critical section: lock row + decide if we can merge

--- a/tr_sys/tr_ars/utils.py
+++ b/tr_sys/tr_ars/utils.py
@@ -36,13 +36,13 @@ from biothings_annotator import annotator
 from pydantic import ValidationError
 from opentelemetry import trace
 
-from tr_sys.celery_gates.expensive_gate import exp_backoff_with_jitter
+from tr_sys.celery_gates.expensive_gate import exp_backoff_with_jitter, constant_backoff_with_jitter
 
 tracer = trace.get_tracer(__name__)
 import asyncio
 import zstandard as zstd
 from tr_sys.celery_gates.context import (expensive_section)
-from celery.exceptions import Retry
+from celery.exceptions import Retry, MaxRetriesExceededError
 
 ARS_ACTOR = {
     'channel': [],
@@ -57,6 +57,8 @@ ARS_ACTOR = {
 NORMALIZER_URL=os.getenv("TR_NORMALIZER") if os.getenv("TR_NORMALIZER") is not None else "https://nodenorm.ci.transltr.io/get_normalized_nodes"
 ANNOTATOR_URL=os.getenv("TR_ANNOTATOR") if os.getenv("TR_ANNOTATOR") is not None else "https://biothings.ncats.io/curie"
 APPRAISER_URL=os.getenv("TR_APPRAISE") if os.getenv("TR_APPRAISE") is not None else "https://answerappraiser.ci.transltr.io/get_appraisal"
+TASK_MAX_RETRIES = int(os.getenv("ARS_EXPENSIVE_TASK_MAX_RETRIES", "100"))
+MERGE_ERROR_MAX_RETRIES = int(os.getenv("ARS_MERGE_ERROR_MAX_RETRIES", "5"))
 
 class QueryGraph():
     def __init__(self,qg):
@@ -689,15 +691,28 @@ def unlock_merge(message: Message) -> None:
         logging.exception("Failed to release merge_semaphore for message %s", getattr(message, "pk", "<unknown>"))
         raise
 
-@shared_task(name="merge-and-post-process", bind=True, acks_late=True, max_retries=20)
-def merge_and_post_process(self, parent_pk,message_to_merge, agent_name):
+
+@shared_task(name="merge-and-post-process", bind=True, acks_late=True, max_retries=None)
+def merge_and_post_process(self, parent_pk, message_to_merge, agent_name, error_retries=0):
     """
     Safe merge & post-process task:
     - Acquire expensive token (expensive_section) first
     - Acquire DB boolean lock (inside short select_for_update atomic)
     - Do merge_received(), post_process() and notifications
     - Always release DB boolean lock in finally
-    - Use self.request.retries for retry/backoff
+
+    Retry functionality:
+    - The built-in Celery retry functionality, tracked by the counter self.request.retries and enforced by Celery,
+      is used for all tasks, contention is the main cause for a retry (no available expensive tokens or the
+      merge db lock is occupied). This is done by setting max_retries to TASK_MAX_RETRIES in expensive_section()
+      and in this function after a failed merge lock acquisition. When this kind of retry occurs we use a quick
+      delay to avoid pointless downtime waiting on ourselves.
+    - Retries for errors in merging are handled separately by error_retries, an arg based counter
+      for actual merge_and_post_process errors, capped by MERGE_ERROR_MAX_RETRIES, enforced by the code here
+      and not celery's internal retry check.
+    - Note that max_retries=None in the merge_and_post_process decorator signature means that callers MUST
+      explicitly declare the max_retries limit. Future changes to this logic should be aware of that and make
+      sure it's always set.
     """
     merged=None
     stats={}
@@ -706,7 +721,7 @@ def merge_and_post_process(self, parent_pk,message_to_merge, agent_name):
     logging.info(f"🚀Starting merge for %s with parent PK: %s"% (agent_name,parent_pk))
     try:
         #Acquire an expensive token so we don't hold DB locked while waiting
-        with expensive_section(self):
+        with expensive_section(self, max_retries=TASK_MAX_RETRIES):
             logging.info("[%s] 🟢 acquired expensive token", self.request.id)
 
             # short critical section: lock row + decide if we can merge
@@ -716,19 +731,13 @@ def merge_and_post_process(self, parent_pk,message_to_merge, agent_name):
                     logging.info("the merge semaphore for agent %s is %s"% (agent_name, parent.merge_semaphore))
                     #try to acquire DB boolean lock
                     if not try_lock_merge(parent):
-                        #someone else already locked it & possibly going through merge, retry ...
-                        retries = self.request.retries
-                        if retries < 10:
-                            delay = 5
-                            if retries >= 7:
-                                logging.warning("⚠️ High retry count (%s) for merge lock on parent=%s agent=%s.Retrying in %ss",retries, parent_pk, agent_name, delay)
-                            else:
-                                logging.info(" 🔄 Merged_version locked for %s. Attempt %s. Retrying in %ss",agent_name, retries, delay)
-                            # raise retry — this will release the expensive token (expensive_section finally), stop the task, requeues it and free the worker
-                            raise self.retry(countdown=delay)
-                        else:
-                            logging.info("❌ Merging failed for %s %s after retries", agent_name, parent_pk)
-                            return
+                        # Another task holds the merge lock. Retry after a quick delay.
+                        delay = constant_backoff_with_jitter()
+                        logging.info("🔄 merge lock held for %s (parent=%s); retrying in %.1fs (retries=%s)",
+                                     agent_name, parent_pk, delay, self.request.retries)
+                        # raise retry — releases the expensive token (expensive_section finally),
+                        # requeues the task and frees the worker.
+                        raise self.retry(countdown=delay, max_retries=TASK_MAX_RETRIES)
                     else:
                         logging.info(" the merge semaphore for agent %s is %s"% (agent_name, parent.merge_semaphore))
                         locked = True
@@ -786,7 +795,19 @@ def merge_and_post_process(self, parent_pk,message_to_merge, agent_name):
         logging.info("Task retry requested — requeueing (parent=%s, retries=%s)",parent_pk, self.request.retries)
         raise
 
+    except MaxRetriesExceededError:
+        # General retry budget exhausted (due to token gate or merge db lock).
+        # This is not a real error, so keep it out of the catch-all Exception handling below.
+        logging.error("❌ Merge gave up after exhausting the retry budget for agent %s pk %s (retries=%s).",
+                      agent_name, parent_pk, self.request.retries)
+        raise
+
     except Exception as e:
+        # TODO - it would be best to categorize and handle different kinds of errors in different ways here.
+        # If there is a deterministic error (ie something wrong with the data) retrying is a waste of time and
+        # hogs resources for no reason. Transient errors such as issues with postgres or service calls to annotator
+        # or appraiser are legitimate reasons to retry and should go through the retry process. It would also be
+        # good to log the kinds of errors occurring and/or make them visible to OTEL.
         logging.info("Problem with merger for agent %s pk: %s " % (agent_name, (parent_pk)))
         logging.info(e, exc_info=True)
         logging.info('error message %s' % str(e))
@@ -794,9 +815,14 @@ def merge_and_post_process(self, parent_pk,message_to_merge, agent_name):
             merged.status='E'
             merged.code = 422
             merged.save()
-        # retry on post_process failure
-        delay = exp_backoff_with_jitter(self.request.retries)
-        raise self.retry(exc=e, countdown=delay)
+        if error_retries >= MERGE_ERROR_MAX_RETRIES:
+            logging.error("Merge for agent %s pk %s failed after %s error retries; giving up.",
+                          agent_name, parent_pk, error_retries)
+            raise
+        delay = exp_backoff_with_jitter(error_retries)
+        raise self.retry(
+            kwargs={"error_retries": error_retries + 1},
+            exc=e, countdown=delay)
 
     finally:
         # Safety net: ensure DB boolean lock released if still held (should generally be False)

--- a/tr_sys/tr_sys/celery_gates/context.py
+++ b/tr_sys/tr_sys/celery_gates/context.py
@@ -3,15 +3,15 @@
 # Relay/tr_sys/tr_sys/celery_gates/context.py
 from contextlib import contextmanager
 from celery.exceptions import Retry, MaxRetriesExceededError
-from .expensive_gate import try_acquire, release, LeaseRenewer, exp_backoff_with_jitter, DEFAULT_LIMIT
+from .expensive_gate import try_acquire, release, LeaseRenewer, exp_backoff_with_jitter, ARS_EXPENSIVE_TOKEN_LIMIT
 from celery.utils.log import get_task_logger
 logger = get_task_logger(__name__)
 
 @contextmanager
-def expensive_section(task_self, limit: int = DEFAULT_LIMIT):
+def expensive_section(task_self, limit: int = ARS_EXPENSIVE_TOKEN_LIMIT):
     """
     Usage: inside a Celery task with `bind=True`:
-        with expensive_section(self, limit=6):
+        with expensive_section(self):
             # do expensive work
     If acquire fails -> raises self.retry(...) to requeue quickly.
     """

--- a/tr_sys/tr_sys/celery_gates/context.py
+++ b/tr_sys/tr_sys/celery_gates/context.py
@@ -3,28 +3,29 @@
 # Relay/tr_sys/tr_sys/celery_gates/context.py
 from contextlib import contextmanager
 from celery.exceptions import Retry, MaxRetriesExceededError
-from .expensive_gate import try_acquire, release, LeaseRenewer, exp_backoff_with_jitter, ARS_EXPENSIVE_TOKEN_LIMIT
+from .expensive_gate import (try_acquire, release, LeaseRenewer, constant_backoff_with_jitter,
+                             ARS_EXPENSIVE_TOKEN_LIMIT)
+from tr_ars.utils import TASK_MAX_RETRIES
 from celery.utils.log import get_task_logger
 logger = get_task_logger(__name__)
 
 @contextmanager
-def expensive_section(task_self, limit: int = ARS_EXPENSIVE_TOKEN_LIMIT):
+def expensive_section(task_self, limit: int = ARS_EXPENSIVE_TOKEN_LIMIT, max_retries: int = TASK_MAX_RETRIES):
     """
     Usage: inside a Celery task with `bind=True`:
-        with expensive_section(self):
+        with expensive_section(self, max_retries=TASK_MAX_RETRIES):
             # do expensive work
     If acquire fails -> raises self.retry(...) to requeue quickly.
     """
     # require task_self (bind=True)
     task_id = str(task_self.request.id)
-    delay = exp_backoff_with_jitter(getattr(task_self.request, "retries", 0))
-    # Try to acquire; if fail -> retry right away with backoff
+    # Try to acquire; if fail -> retry after a quick delay
     try:
         if not try_acquire(task_id, limit=limit):
-            # Use task_self.request.retries (celery increments retries on retry()).
-            logger.debug("Task %s could not acquire token; retrying in %ss (retries=%s)", task_id, delay, getattr(task_self.request, "retries", 0))
+            delay = constant_backoff_with_jitter()
+            logger.debug("Task %s could not acquire token; retrying in %.1fs (retries=%s)", task_id, delay, getattr(task_self.request, "retries", 0))
             # We raise self.retry so Celery releases the worker and requeues.
-            raise task_self.retry(countdown=delay)
+            raise task_self.retry(countdown=delay, max_retries=max_retries)
     except MaxRetriesExceededError:
         # Out of retries — fail gracefully and log
         logger.warning("Task %s exceeded max retries while waiting for expensive token; failing.", task_id)

--- a/tr_sys/tr_sys/celery_gates/expensive_gate.py
+++ b/tr_sys/tr_sys/celery_gates/expensive_gate.py
@@ -64,7 +64,7 @@ def try_acquire(task_id: str, limit: int = ARS_EXPENSIVE_TOKEN_LIMIT) -> bool:
     script = _load_acquire_script()
     try:
         res = script(keys=[ZKEY], args=[now_ms(), LEASE_MS, limit, task_id])
-        logger.warning("try_acquire task=%s limit=%s res=%s redis=%s zkey=%s",
+        logger.debug("try_acquire task=%s limit=%s res=%s redis=%s zkey=%s",
                     task_id, limit, res, REDIS_URL, ZKEY)
         return bool(res)
     except redis.RedisError:
@@ -93,11 +93,27 @@ def exp_backoff_with_jitter(retries: int, base: int = 1, max_delay: int = 30) ->
     """
     Exponential backoff with jitter.
     `retries` is the current retry count (0..).
+
+    Use this for retrying genuine failures (e.g. a downstream error), NOT for
+    concurrency-limiter contention. Use constant_backoff_with_jitter for that.
     """
     rcount = max(0, int(retries or 0))
     delay = min(max_delay, base * (2 ** rcount))
     delay = int(delay * random.uniform(0.8, 1.2)) #makes first retry ~2sec, next ~4sec, etc. capping at 30 sec
     return max(1, delay)
+
+
+def constant_backoff_with_jitter(base: float = 2,
+                                 spread: float = 3) -> float:
+    """
+    Short, roughly-constant backoff with jitter. Intended to be used for lock contention and internal throttling.
+    Unlike exponential backoff, this keeps the task queue polling on a short, steady cadence so that a token
+    freed by a finishing task is picked up within a few seconds instead of sitting idle for the longer delays
+    used for failure retries. The delay is 2-5 seconds by default. Note that we don't want to go
+    too much faster than that because the retry process isn't exactly cheap, each failed check for available
+    workers adds another full round trip through the celery broker.
+    """
+    return base + random.random() * spread
 
 
 class LeaseRenewer:

--- a/tr_sys/tr_sys/celery_gates/expensive_gate.py
+++ b/tr_sys/tr_sys/celery_gates/expensive_gate.py
@@ -13,7 +13,7 @@ logger = get_task_logger(__name__)
 # Config via env (set these in your Helm values / CI)
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
 ZKEY = os.getenv("ARS_EXPENSIVE_ZKEY", "ars:expensive_tokens")
-DEFAULT_LIMIT = int(os.getenv("ARS_EXPENSIVE_LIMIT", "12"))       # default token limit
+ARS_EXPENSIVE_TOKEN_LIMIT = int(os.getenv("ARS_EXPENSIVE_LIMIT", "12"))       # default token limit
 LEASE_MS = int(os.getenv("ARS_EXPENSIVE_LEASE_MS", "180000"))   # default lease 3 minutes (ms)
 RENEW_EVERY_SEC = int(os.getenv("ARS_EXPENSIVE_RENEW_SEC", "15"))  # renew interval
 
@@ -56,13 +56,11 @@ def now_ms() -> int:
     return int(time.time() * 1000)
 
 
-def try_acquire(task_id: str, limit: Optional[int] = None) -> bool:
+def try_acquire(task_id: str, limit: int = ARS_EXPENSIVE_TOKEN_LIMIT) -> bool:
     """
     Atomically attempt to acquire a lease token for task_id.
     Returns True when token claimed, False otherwise.
     """
-    if limit is None:
-        limit = DEFAULT_LIMIT
     script = _load_acquire_script()
     try:
         res = script(keys=[ZKEY], args=[now_ms(), LEASE_MS, limit, task_id])


### PR DESCRIPTION
This PR aims to improve performance, resource utilization, and error reporting for the merge_and_post_process celery task queue implementation.

**Issues Addressed**
Currently, merge_and_post_process celery tasks are retried for three broad reasons: a failure to acquire an 'expensive token', failure to acquire a merge db lock, or when any Exception is raised during merge_and_post_process. All three of these share the same retry implementation, retry counter, and an exponential back off behavior that delays the next attempt by increasing amounts. The exponential back off delay is tuned to be quite slow, in an attempt to give downstream services time to recover in event of an error, but for normal 'expensive token' or db lock contention this isn't appropriate and results in unnecessary downtime when long back off delays occur while resources might already be available. Additionally, if deterministic errors occur, the current implementation still retries them up to the shared limit of retries even though they will fail again, wasting time and resources, with long delays in between.

**The Solution**
This PR separates the retry logic for Exceptions from retries due to contention, allowing us to tune them differently. By default it attempts retries due to contention much faster and for more attempts (every 2-5 seconds up to 100 times) and retries due to exceptions with the existing exponential back off (up to 30 seconds) but only for 5 attempts.

**DB Lock Silent Failures**
Here we also address a mismatch for how db lock retries were handled vs token contention. Previously the db lock had hard coded retry values inside the merge_and_post_process function (with a cap of 10 instead of 20), and when it was exhausted and gave up it silently caught the error with only a log message. Now the db lock contention retry shares the implementation of the token contention retry, and raises the failure when it occurs, allowing Celery and OTEL to recognize it.

**New ENV Vars**
This introduces two new env vars for tuning this retry logic, but does not attempt to alter the helm chart due to settings being applied in jenkins outside of this repo. That should be addressed in future work.

ARS_EXPENSIVE_TASK_MAX_RETRIES (the overall shared retry limit, default 100)
ARS_MERGE_ERROR_MAX_RETRIES (retry limit for real errors, default 5)

**Misc.**
This also changes a logging call in expensive_gate indicating a token acquisition is being attempted from warning to debug, to avoid clogging up logs and unnecessary log writes, because this is a normal operation that should happen all the time, and more frequently with these changes.

**Future work**
It is important to note that there are still significant improvements that could be made for error handling here. All exceptions are handled in the same way. Except for other logs outside of merge_and_post_process it is not apparent what kind of issue caused Exceptions or retries for them, which still causes deterministic errors to be retried unnecessarily, and hurts our ability to diagnose issues. Perhaps more importantly, according to Claude, errors that occur when hitting the node annotator or appraiser are swallowed and don't even cause Exceptions to be raised into the merge_and_post_process - so at least some of the kinds of errors that it is most appropriate to retry with exponential back off on probably aren't even being retried. 